### PR TITLE
Fix auth post json

### DIFF
--- a/requests_llnw_auth.py
+++ b/requests_llnw_auth.py
@@ -27,6 +27,8 @@ class LLNWAuth(requests.auth.AuthBase):
         timestamp = str(int(round(time.time() * 1000)))
         if request_body == None:
             request_body = ''
+        if type(request_body) is bytes:
+            request_body = str(request_body, 'utf-8')
         data = f'{method}{auth_url}{query_string}{timestamp}{request_body}'
         token = hmac.new(binascii.unhexlify(self.api_key), msg = data.encode('utf-8'), digestmod = hashlib.sha256).hexdigest()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='requests-llnw-auth',
-    version='1.0.0',
+    version='1.0.1',
     description='LLNW header-based auth plugin for Python Requests',
     long_description=open('README.md').read().strip(),
     long_description_content_type='text/markdown',
@@ -11,6 +11,6 @@ setup(
     url='https://github.com/llnw/requests-llnw-auth',
     license='Apache License 2.0',
     py_modules=['requests_llnw_auth'],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     install_requires=['requests>=2.22.0']
 )


### PR DESCRIPTION
When making a JSON POST requests with the _requests_ module, the token is bad due to the _binary_ type of the requests body.
Adding a test if the body is a _binary_ to change the type from _binary_ to _string_